### PR TITLE
Add OWNERS file for etcdlabs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - ahrtr           # Benjamin Wang <wachao@vmware.com> <benjamin.ahrtr@gmail.com>
+  - mitake          # Hitoshi Mitake <h.mitake@gmail.com>
+  - serathius       # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>
+  - ptabor          # Piotr Tabor <piotr.tabor@gmail.com>
+  - spzala          # Sahdev Zala <spzala@us.ibm.com>
+  - wenjiaswe       # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
+reviewers:
+  - jmhbnz          # James Blair <jablair@redhat.com> <mail@jamesblair.net>
+  - fuweid          # Wei Fu <fuweid89@gmail.com>


### PR DESCRIPTION
This pull request proposes a layout for the OWNERS file we need to add to each non archived subproject under the etcd-io github organisation as part of the creation of sig-etcd.

Refer to OWNERS documentation: https://www.kubernetes.dev/docs/guide/owners
