### PR TITLE
Update OWNERS file with current maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,9 @@
 
 approvers:
   - ahrtr           # Benjamin Wang <wachao@vmware.com> <benjamin.ahrtr@gmail.com>
-  - mitake          # Hitoshi Mitake <h.mitake@gmail.com>
   - serathius       # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>
-  - ptabor          # Piotr Tabor <piotr.tabor@gmail.com>
   - spzala          # Sahdev Zala <spzala@us.ibm.com>
   - wenjiaswe       # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
-reviewers:
   - jmhbnz          # James Blair <jablair@redhat.com> <mail@jamesblair.net>
+reviewers:
   - fuweid          # Wei Fu <fuweid89@gmail.com>


### PR DESCRIPTION
While fixing https://github.com/etcd-io/etcdlabs/issues/293 I realised I don't have permissions in this repo to be able to close the issue etc, updating `OWNERS` file to remove emeritus retired maintainers and updating my role to maintainer.

Think we might need to create a team in `kubernetes/org` for this repo as well but lets get the maintainer listing in this `OWNERS` file corrected first.

cc @ahrtr, @serathius 